### PR TITLE
Update images LTS and latest

### DIFF
--- a/node:10.16.3-alpine.Dockerfile
+++ b/node:10.16.3-alpine.Dockerfile
@@ -1,0 +1,24 @@
+# Current LTS Support 10.x
+FROM node:10.16.3-alpine
+
+# Maintainer Information
+LABEL maintainer="ZRP Aplicações Informáticas LTDA - ME <zrp@zrp.com.br>"
+LABEL vendor="ZRP Aplicações Informáticas LTDA - ME"
+LABEL license="GPLv3"
+
+# Configure where container network and pwd
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+
+# extend path to read from local binaries and project binaries
+ENV NODEJS_VERSION="10.16.3" \
+    APP_PATH=/home/node/app \
+    PATH=/usr/local/bin/:/home/node/app/bin/:$PATH
+
+# install custom scripts into local binaries
+COPY alpine_rootfs /usr/local/bin/
+COPY shared /usr/local/bin
+
+# run the app
+ENTRYPOINT ["/usr/local/bin/docker_entrypoint_without_gosu"]
+CMD ["ash"]

--- a/node:10.16.3.Dockerfile
+++ b/node:10.16.3.Dockerfile
@@ -1,0 +1,44 @@
+# Current LTS Support 10.x
+FROM node:10.16.3
+
+# Maintainer Information
+LABEL maintainer="ZRP Aplicações Informáticas LTDA - ME <zrp@zrp.com.br>"
+LABEL vendor="ZRP Aplicações Informáticas LTDA - ME"
+LABEL license="GPLv3"
+
+# Configure where container network and pwd
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+
+# extend path to read from local binaries and project binaries
+ENV NODEJS_VERSION="10.16.3" \
+    GOSU_VERSION="1.10" \
+    APP_PATH=/home/node \
+    PATH=/usr/local/bin/:/home/node/app/bin/:$PATH
+
+RUN set -ex; \
+    fetchDeps='ca-certificates wget'; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu nobody true; \
+    apt-get purge -y --auto-remove $fetchDeps
+
+# Install dependencies and yarn globally
+RUN npm install -g yarn && npm upgrade -g yarn
+
+# install custom scripts into local binaries
+COPY rootfs /usr/local/bin/
+COPY shared /usr/local/bin
+
+# run the app
+ENTRYPOINT ["/usr/local/bin/docker_entrypoint"]
+CMD ["bash"]

--- a/node:12.9.0-alpine.Dockerfile
+++ b/node:12.9.0-alpine.Dockerfile
@@ -1,0 +1,24 @@
+# Current LTS Support 12.x
+FROM node:12.9.0-alpine
+
+# Maintainer Information
+LABEL maintainer="ZRP Aplicações Informáticas LTDA - ME <zrp@zrp.com.br>"
+LABEL vendor="ZRP Aplicações Informáticas LTDA - ME"
+LABEL license="GPLv3"
+
+# Configure where container network and pwd
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+
+# extend path to read from local binaries and project binaries
+ENV NODEJS_VERSION="12.9.0" \
+    APP_PATH=/home/node/app \
+    PATH=/usr/local/bin/:/home/node/app/bin/:$PATH
+
+# install custom scripts into local binaries
+COPY alpine_rootfs /usr/local/bin/
+COPY shared /usr/local/bin
+
+# run the app
+ENTRYPOINT ["/usr/local/bin/docker_entrypoint_without_gosu"]
+CMD ["ash"]

--- a/node:12.9.0.Dockerfile
+++ b/node:12.9.0.Dockerfile
@@ -1,0 +1,44 @@
+# Current LTS Support 12.x
+FROM node:12.9.0
+
+# Maintainer Information
+LABEL maintainer="ZRP Aplicações Informáticas LTDA - ME <zrp@zrp.com.br>"
+LABEL vendor="ZRP Aplicações Informáticas LTDA - ME"
+LABEL license="GPLv3"
+
+# Configure where container network and pwd
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+
+# extend path to read from local binaries and project binaries
+ENV NODEJS_VERSION="12.9.0" \
+    GOSU_VERSION="1.10" \
+    APP_PATH=/home/node \
+    PATH=/usr/local/bin/:/home/node/app/bin/:$PATH
+
+RUN set -ex; \
+    fetchDeps='ca-certificates wget'; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu nobody true; \
+    apt-get purge -y --auto-remove $fetchDeps
+
+# Install dependencies and yarn globally
+RUN npm install -g yarn && npm upgrade -g yarn
+
+# install custom scripts into local binaries
+COPY rootfs /usr/local/bin/
+COPY shared /usr/local/bin
+
+# run the app
+ENTRYPOINT ["/usr/local/bin/docker_entrypoint"]
+CMD ["bash"]


### PR DESCRIPTION
Add new images for NodeJS LTS and latest versions.
Fall back to use standard Node images as mhart/node images had some permission issues.
Bugged images not removed as might have some users using it.